### PR TITLE
Project refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,13 +13,11 @@ RUN rm -fr /opt/uptime && git clone --depth=1 https://github.com/fzaninotto/upti
 WORKDIR /opt/uptime
 RUN npm install
 
-ADD config_template.yaml /opt/uptime/config/config_template.yaml
 RUN rm /opt/uptime/config/default.yaml
+ADD default.yaml /opt/uptime/config/default.yaml
 
 ADD run-uptime.sh /opt/run-uptime.sh
 RUN chmod +x /opt/run-uptime.sh
-
-
 
 ENTRYPOINT ["/opt/run-uptime.sh"]
 CMD ["rootpass"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A dockerized [Uptime](https://github.com/fzaninotto/uptime) Container
 
 ```
 # Run MongoDB
-docker run -d --name mongodb dockerfile/mongodb
+docker run -d --name mongodb mongo
 
 # Run Uptime and link MongoDB
 docker run -d -p 8082:8082 --name uptime --link mongodb:mongodb -i -t usman/docker-uptime

--- a/default.yaml
+++ b/default.yaml
@@ -1,11 +1,7 @@
 url: 'http://localhost:8082'
 
 mongodb:
-  server:   MONGO_SERVER
-  database: uptime
-  user:     root 
-  password: MONGO_PASSWORD
-  connectionString:       # alternative to setting server, database, user and password separately
+  connectionString: mongodb://mongodb/uptime
 
 monitor:
   name:                   origin
@@ -54,6 +50,3 @@ webPageTest:
   server: 'http://www.webpagetest.org'
   key:
   testOptions: 
-
-
-  

--- a/run-uptime.sh
+++ b/run-uptime.sh
@@ -8,22 +8,6 @@ then
 	cp -r /tmp/uptime/config /opt/uptime/config	
 fi
 
-
-echo "db.stats()" > testUser.js
-mongo ${MONGODB_PORT_28017_TCP_ADDR}/uptime -u root -p ${1} testUser.js ||  {
-
-	echo "Password needs to be Added"
-	echo "db = db.getSiblingDB('admin')" > init-mongo.js;
-	echo "db.addUser({user:'root', pwd:'${1}', roles: ['root']})" >> init-mongo.js;
-	echo "db = db.getSiblingDB('uptime')" >> init-mongo.js;
-	echo "db.addUser({user:'root', pwd:'${1}', roles: ['root']})" >> init-mongo.js;
-
-	mongo ${MONGODB_PORT_28017_TCP_ADDR} init-mongo.js;
-};
-
-sed "s/MONGO_SERVER/${MONGODB_PORT_27017_TCP_ADDR}/g" config/config_template.yaml | sed "s/MONGO_PASSWORD/${1}/g" > config/default.yaml
-
-
 # Run custom initilization script if it exists
 if [ -f /tmp/uptime/init-uptime.sh ];
 then


### PR DESCRIPTION
I have changed some thinks. Instead of initializing the mongodb with a default user I expect to have a zero configuried database just for uptime. This is more compatible with your mongodb example in the readme.

All other configuration needs should be provided via an `production.yaml` or `development.yaml` mounted as volume in `/tmp/uptime/`.

Example docker-compose file:

```
mongo:
  image: mongo:3.0.1
uptime:
  image: werk85/docker-uptime
  environment:
    NODE_ENV: development
  links:
  - mongo:mongodb
  ports:
  - 8082:8082
  volumes:
  - .:/tmp/uptime
```
